### PR TITLE
add KSP-AVC version file for auto-module checking

### DIFF
--- a/For release/Firespitter/Firespitter.version
+++ b/For release/Firespitter/Firespitter.version
@@ -4,5 +4,10 @@
   "VERSION": {
     "MAJOR": 6,
     "MINOR": 3
+  },
+  "KSP_VERSION": {
+    "MAJOR": 0,
+    "MINOR": 23,
+    "PATCH": 5
   }
 }


### PR DESCRIPTION
Dearest Firespitter authors/maintainers,

I just started working with @tyrope on a project to add a version checker to KSP modules. I know that it would help me a lot! He said that helping him contact module authors would be really helpful so here I am! If you would be willing to accept this patch we would really appreciate it!

The KSP Addon Version Checker is my attempt at trying to have some sort of version checking available for people who play KSP with lots of mods. more information and source available [right here on github](https://github.com/tyrope/KSP-addon-version-checker)
