### PR TITLE
fixed tail rotor thrust inversion bug

### DIFF
--- a/Firespitter/engine/Stock based modules/FStailRotorThrust.cs
+++ b/Firespitter/engine/Stock based modules/FStailRotorThrust.cs
@@ -153,7 +153,7 @@ namespace Firespitter.engine
 
                 if (steeringInput.y > 0)
                 {
-                    partTransform.localRotation = defaultRotation.Inverse();
+                    partTransform.localRotation = Quaternion.FromToRotation(new Vector3(0, 1, 0), new Vector3(0, -1, 0)) * defaultRotation;
                 }
                 else
                 {


### PR DESCRIPTION
FStailRotorThrust inverts the rotation of the thrust transformation when rotating against the thrust transforms direction. This does only work with a rotation of exactly 180 degrees. Beter approach: rotate localRotation 180° around X- or Z-Axis. The KAX tail rotor should work again after this fix.