### PR TITLE
Update part.cfg

### DIFF
--- a/For release/Firespitter/Parts/Engine/FS_propellerFolding/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_propellerFolding/part.cfg
@@ -78,7 +78,7 @@ MODULE
 	ignitionThreshold = 0.1
 	minThrust = 0
 	maxThrust = 35
-	heatProduction = 300
+	heatProduction = 30
 	useEngineResponseTime = True
 	engineAccelerationSpeed = 20
 	engineDecelerationSpeed = 20


### PR DESCRIPTION
300 heat production for such a small propeller is an insanity. Bigger Firespitter electric propeller (FS1ENE) only has 30. Squad JET engine only has 40... and it's fuel-burning btw.
Thus 300 is a typo. Fiery overheating vehicle-exploding typo. 
It must be fixed.