### PR TITLE
EngineID fields for FSPropellerSpinner

### DIFF
--- a/Firespitter/engine/FSengineWrapper.cs
+++ b/Firespitter/engine/FSengineWrapper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using UnityEngine;
 
 namespace Firespitter.engine
 {
@@ -40,6 +41,15 @@ namespace Firespitter.engine
                 }
             }
             //Debug.Log("FSengineWrapper: engine type is " + type.ToString());
+        }
+
+        public FSengineWrapper(Part part, string name)
+        {
+            engineFX = part.Modules.OfType<ModuleEnginesFX>().Where(p => p.engineID == name).FirstOrDefault();
+            if (engineFX != null)
+                type = EngineType.ModuleEngineFX;
+            //Debug.Log("FSengineWrapper: engine type is " + type.ToString());
+            
         }
 
         public float maxThrust

--- a/Firespitter/engine/FSplanePropellerSpinner.cs
+++ b/Firespitter/engine/FSplanePropellerSpinner.cs
@@ -8,6 +8,8 @@ namespace Firespitter.engine
     public class FSplanePropellerSpinner : PartModule
     {
         [KSPField]
+        public string engineID;
+        [KSPField]
         public string propellerName = "propeller";
         [KSPField]
         public float rotationSpeed = -320f; // in RPM
@@ -82,7 +84,11 @@ namespace Firespitter.engine
         public override void OnStart(PartModule.StartState state)
         {
             base.OnStart(state);
-            engine = new Firespitter.engine.FSengineWrapper(part);
+
+            if (engineID == String.Empty || engineID == "")
+                engine = new Firespitter.engine.FSengineWrapper(part);
+            else
+                engine = new Firespitter.engine.FSengineWrapper(part, engineID);
 
             if (engine.type == FSengineWrapper.EngineType.FSengine)
             {


### PR DESCRIPTION
Allows an engineID field to be specified for FSplanePropellerSpinner, which links it to a moduleEnginesFX with the same engineID instead of the first found engine module.

Useful for multi-engine parts.