### PR TITLE
Adding bulkheadProfiles to parts

### DIFF
--- a/For release/Firespitter/Parts/Aero/FS_bomberWing/part.cfg
+++ b/For release/Firespitter/Parts/Aero/FS_bomberWing/part.cfg
@@ -21,6 +21,8 @@ subcategory = 0
 title = FS1BW Firespitter Bomber Wing
 manufacturer = Bitesized Industries
 description = It's mostly wood and canvas, but it will get you where you are going.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/Aero/FS_bomberWingExtender/part.cfg
+++ b/For release/Firespitter/Parts/Aero/FS_bomberWingExtender/part.cfg
@@ -28,6 +28,8 @@ subcategory = 0
 title = FS1BW Firespitter Bomber Wing
 manufacturer = Bitesized Industries
 description = It's mostly wood and canvas, but it will get you where you are going.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/Aero/FS_fighterJetElevator/part.cfg
+++ b/For release/Firespitter/Parts/Aero/FS_fighterJetElevator/part.cfg
@@ -21,6 +21,7 @@ subcategory = 0
 title = FS1F86E-S Fighter Jet Elevator
 manufacturer = Bitesized Industries
 description = A tail control surface from a classic fighter jet. The S-series has custom lift code.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1

--- a/For release/Firespitter/Parts/Aero/FS_fighterJetRudder/part.cfg
+++ b/For release/Firespitter/Parts/Aero/FS_fighterJetRudder/part.cfg
@@ -21,6 +21,7 @@ subcategory = 0
 title = FS1F86R-S Fighter Jet Rudder
 manufacturer = Bitesized Industries
 description = A tail control surface from a classic fighter jet. The S-series has custom lift code.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1

--- a/For release/Firespitter/Parts/Aero/FS_fighterJetWing/part.cfg
+++ b/For release/Firespitter/Parts/Aero/FS_fighterJetWing/part.cfg
@@ -20,6 +20,8 @@ subcategory = 0
 title = FS1F86-S Fighet Jet Wing
 manufacturer = Bitesized Industries
 description = A wing from an F-86, a classic fighter jet. Includes leading edge slats and flaps. The S-series has custom lift code.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/Aero/FS_fighterWing/part.cfg
+++ b/For release/Firespitter/Parts/Aero/FS_fighterWing/part.cfg
@@ -20,6 +20,8 @@ subcategory = 0
 title = FS1W Firespitter Wing
 manufacturer = Bitesized Industries
 description = It's a wing torn off an old fighter plane.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/Aero/FS_oblongNoseIntake/part.cfg
+++ b/For release/Firespitter/Parts/Aero/FS_oblongNoseIntake/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS1ONI Oblong Nose Intake
 manufacturer = Bitesized Industries
 description = A nose air intake for a fighter jet
+bulkheadProfiles = oblong
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Aero/FS_tailWing/part.cfg
+++ b/For release/Firespitter/Parts/Aero/FS_tailWing/part.cfg
@@ -21,6 +21,7 @@ subcategory = 0
 title = FS1TW2 Tail Wing
 manufacturer = Bitesized Industries
 description = This small tail wing will let you yaw and pitch as smooth as butter. We wish buttery smoothness was actually useful, instead of all this lift and drag stuff.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1

--- a/For release/Firespitter/Parts/Aero/FS_tailWingLarge/part.cfg
+++ b/For release/Firespitter/Parts/Aero/FS_tailWingLarge/part.cfg
@@ -21,6 +21,7 @@ subcategory = 0
 title = FS1TW3 Large Tail Wing
 manufacturer = Bitesized Industries
 description = This large tail wing will let you yaw and pitch as smooth as butter. We wish buttery smoothness was actually useful, instead of all this lift and drag stuff.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1

--- a/For release/Firespitter/Parts/Aero/FS_winglet/part.cfg
+++ b/For release/Firespitter/Parts/Aero/FS_winglet/part.cfg
@@ -22,6 +22,8 @@ title = FS1TW1 Tail Winglet
 manufacturer = Bitesized Industries
 description = This thing goes on the back of your plane so you can pitch it. If that's the sort of thing you care about. No pressure.
 bulkheadProfiles = srf
+
+// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,1
 
 // --- node definitions ---

--- a/For release/Firespitter/Parts/Aero/FS_winglet/part.cfg
+++ b/For release/Firespitter/Parts/Aero/FS_winglet/part.cfg
@@ -21,6 +21,7 @@ subcategory = 0
 title = FS1TW1 Tail Winglet
 manufacturer = Bitesized Industries
 description = This thing goes on the back of your plane so you can pitch it. If that's the sort of thing you care about. No pressure.
+bulkheadProfiles = srf
 attachRules = 0,1,0,0,1
 
 // --- node definitions ---

--- a/For release/Firespitter/Parts/Command/FS_apacheCockpit/part.cfg
+++ b/For release/Firespitter/Parts/Command/FS_apacheCockpit/part.cfg
@@ -26,6 +26,8 @@ subcategory = 0
 title = FS2OC Attack Helicopter Cockpit
 manufacturer = Bitesized Industries
 description = Strike fear into the Kraken, when you go on the attack with this cockpit filled to the brim with high tech doodads.
+bulkheadProfiles = oblong
+
 //attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,1,0
 

--- a/For release/Firespitter/Parts/Command/FS_bomberCockpit/part.cfg
+++ b/For release/Firespitter/Parts/Command/FS_bomberCockpit/part.cfg
@@ -29,6 +29,8 @@ subcategory = 0
 title = FS1FH Bomber Cockpit
 manufacturer = Bitesized Industries
 description = The cockpit from an old K-17 Flying House. For some reason, there is always a great painter waiting around to paint something fun on the nose of these things.
+bulkheadProfiles = size2
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,1,0
 

--- a/For release/Firespitter/Parts/Command/FS_copterCockpit/part.cfg
+++ b/For release/Firespitter/Parts/Command/FS_copterCockpit/part.cfg
@@ -26,6 +26,8 @@ subcategory = 0
 title = FS2CP Helicopter Cockpit
 manufacturer = Bitesized Industries
 description = The unoficially named "Whooey" Helicopter was the work horse of the Kerbal Marines. The name comes from the sound of relief any time someone landed without something exploding.
+bulkheadProfiles = size1
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,1,0
 

--- a/For release/Firespitter/Parts/Command/FS_fighterCockpit/part.cfg
+++ b/For release/Firespitter/Parts/Command/FS_fighterCockpit/part.cfg
@@ -26,6 +26,7 @@ subcategory = 0
 title = FS1OC Fighter Inline Cockpit
 manufacturer = Bitesized Industries
 description = A last generation inline cockpit. For all your dog fighting needs!
+bulkheadProfiles = oblong
 
 //attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,1,0

--- a/For release/Firespitter/Parts/Engine/FS_PROpeller/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_PROpeller/part.cfg
@@ -28,6 +28,7 @@ subcategory = 0
 title = FS1PRO Customizable Propeller engine
 manufacturer = Bitesized Industries
 description = A totally customizable propeller engine. Tweak the engine size and power, the number of blades and their length.
+bulkheadProfiles = size1
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,0,0

--- a/For release/Firespitter/Parts/Engine/FS_PROpellerElectric/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_PROpellerElectric/part.cfg
@@ -28,6 +28,7 @@ subcategory = 0
 title = FS1PRE Customizable Electric Propeller engine
 manufacturer = Bitesized Industries
 description = A totally customizable electric propeller engine. Tweak the engine size and power, the number of blades and their length.
+bulkheadProfiles = size1
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,0,0

--- a/For release/Firespitter/Parts/Engine/FS_VTOLengine/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_VTOLengine/part.cfg
@@ -41,6 +41,7 @@ subcategory = 0
 title = FS2V VTOL engine
 manufacturer = Bitesized Industries
 description = Go up, go forth! Set up rotation actions in the hangar action editor. Right click to invert rotation after launch.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,0,0,0

--- a/For release/Firespitter/Parts/Engine/FS_copterRotorFenestron/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_copterRotorFenestron/part.cfg
@@ -35,6 +35,7 @@ subcategory = 0
 title = FS2F helicopter Fenestron
 manufacturer = Bitesized Industries
 description = This helicopter tail rotor will make sure you can rotate your craft. Uses Electricity when steering. To keep steering logical, keep the little arrow pointed down! (Can be inverted by right clicking)
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,0,1,1

--- a/For release/Firespitter/Parts/Engine/FS_copterRotorMain/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_copterRotorMain/part.cfg
@@ -47,6 +47,7 @@ subcategory = 0
 title = FS Helicopter Main Rotor, Tweakable
 manufacturer = Bitesized Industries
 description = This engine will take you up, up, dooown!
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,0,0,0

--- a/For release/Firespitter/Parts/Engine/FS_copterRotorMainElectric/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_copterRotorMainElectric/part.cfg
@@ -34,6 +34,7 @@ subcategory = 0
 title = FS2ME Electric Helicopter Main Rotor
 manufacturer = Bitesized Industries
 description = When there's just not enough oxygen to burn your dead dinosaurs, you will want to fly using this potato battery compatible engine. Warning: potato battery array will need to be massive! Keep the arrow pointed forward when placing!
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,0,0,0

--- a/For release/Firespitter/Parts/Engine/FS_copterRotorTail/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_copterRotorTail/part.cfg
@@ -43,6 +43,7 @@ subcategory = 0
 title = FS test tail engine
 manufacturer = Bitesized Industries
 description = This engine will take you up, up, dooown! Make sure to attach our patented tail rotor FS2F (sold separately) to control your rotation. Keep the arrow pointed forward when placing!
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,0,0,0

--- a/For release/Firespitter/Parts/Engine/FS_lancasterEngine/ogear.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_lancasterEngine/ogear.cfg
@@ -42,6 +42,7 @@ subcategory = 0
 title = FS1LEG Lancaster Engine
 manufacturer = Bitesized Industries
 description = A V12 Rolls Royce Merlin engine and a landing gear. Powered by a wizard!
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,1,1,1

--- a/For release/Firespitter/Parts/Engine/FS_lancasterEngine/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_lancasterEngine/part.cfg
@@ -39,6 +39,7 @@ subcategory = 0
 title = FS1LEG Lancaster Engine
 manufacturer = Bitesized Industries
 description = A V12 Rolls Royce Merlin engine, no landing gear. Powered by a wizard!
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,1,1,1

--- a/For release/Firespitter/Parts/Engine/FS_noseEngine/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_noseEngine/part.cfg
@@ -35,6 +35,7 @@ subcategory = 0
 title = FS1EN Nose Mounted Engine
 manufacturer = Bitesized Industries
 description = A smaller propeller engine for nimble fighter planes. 0.5m diameter
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,0,0,0

--- a/For release/Firespitter/Parts/Engine/FS_noseEngineElectric/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_noseEngineElectric/part.cfg
@@ -37,6 +37,7 @@ subcategory = 0
 title = FS1ENE Nose Mounted Electric Engine
 manufacturer = Bitesized Industries
 description = A smaller electric propeller engine for nimble fighter planes. 0.5m diameter
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,0,0,0

--- a/For release/Firespitter/Parts/Engine/FS_oblongTailJet/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_oblongTailJet/part.cfg
@@ -39,6 +39,7 @@ subcategory = 0
 title = FS1OJ Oblong Tail Jet
 manufacturer = Bitesized Industries
 description = An inline tail jet for old school jet fighters
+bulkheadProfiles = oblong
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Engine/FS_propellerFolding/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_propellerFolding/part.cfg
@@ -38,6 +38,7 @@ subcategory = 0
 title = FS1FPE Folding Electric Propeller
 manufacturer = Bitesized Industries
 description = A small folding electric propeller engine for air ships and missions to other planets
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,0,0,0

--- a/For release/Firespitter/Parts/Engine/FS_swampEngine/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_swampEngine/part.cfg
@@ -40,6 +40,7 @@ subcategory = 0
 title = FS3SE Swamp Engine
 manufacturer = Bitesized Industries
 description = It's obviously not just an upscaled table fan. Obviously!
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1

--- a/For release/Firespitter/Parts/Engine/FS_turboProp/part.cfg
+++ b/For release/Firespitter/Parts/Engine/FS_turboProp/part.cfg
@@ -31,6 +31,7 @@ subcategory = 0
 title = FS1TP Turboprop Engine
 manufacturer = Bitesized Industries
 description = A modern turboprop engine
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,1,1,1

--- a/For release/Firespitter/Parts/FS_BiplaneCockpit.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneCockpit.cfg
@@ -30,7 +30,7 @@ manufacturer = Bitesized Industries
 description = From a time when Men were Men, and Kerbals were Kerbals. Dress code is strictly enforced.
 bulkheadProfiles = oblong
 
-//attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,1,0
 
 // --- standard part parameters ---

--- a/For release/Firespitter/Parts/FS_BiplaneCockpit.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneCockpit.cfg
@@ -28,6 +28,7 @@ subcategory = 0
 title = FS4BC Biplane Cockpit
 manufacturer = Bitesized Industries
 description = From a time when Men were Men, and Kerbals were Kerbals. Dress code is strictly enforced.
+bulkheadProfiles = oblong
 
 //attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,1,0

--- a/For release/Firespitter/Parts/FS_BiplaneElevator.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneElevator.cfg
@@ -23,6 +23,8 @@ subcategory = 0
 title = FS4E Biplane Elevator (special aero)
 manufacturer = Bitesized Industries
 description = A tail elevator from an old Biplane. Provides only Pitch control unless re-configured.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/FS_BiplaneEngine.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneEngine.cfg
@@ -26,6 +26,7 @@ subcategory = 0
 title = Biplane Engine
 manufacturer = Bitesized Industries
 description = TBD
+bulkheadProfiles = size1
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,0,0

--- a/For release/Firespitter/Parts/FS_BiplaneRudder.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneRudder.cfg
@@ -22,6 +22,8 @@ subcategory = 0
 title = FS4R Biplane Rudder (special aero)
 manufacturer = Bitesized Industries
 description = A rudder from an old Biplane. Provides only Yaw control unless re-configured.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/FS_BiplaneSkid.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneSkid.cfg
@@ -24,6 +24,7 @@ subcategory = 0
 title = FS4SKD Biplane Tail Skid
 manufacturer = Bitesized Industries
 description = When wheels are just too high tech! You can actually steer with this thing on the tail of your plane. It will also help slow you down after a landing (without keeping you from taking off from a stand still). For extra protection, use some of these in a non steering setup on your wing tips for added impact protection, just like on the historic Fokker DR1.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1

--- a/For release/Firespitter/Parts/FS_BiplaneTailFuselage.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneTailFuselage.cfg
@@ -22,6 +22,8 @@ subcategory = 0
 title = FS4FT Biplane Tail Fuselage
 manufacturer = Bitesized Industries
 description = A tail section from an old bi-plane
+bulkheadProfiles = oblong
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,0,1,1
 

--- a/For release/Firespitter/Parts/FS_BiplaneWheel.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneWheel.cfg
@@ -28,6 +28,7 @@ subcategory = 0
 title = FS4LGD Biplane Wheel Pair
 manufacturer = Bitesized Industries
 description = A front landing gear from a biplane
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,1

--- a/For release/Firespitter/Parts/FS_BiplaneWingCenter.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneWingCenter.cfg
@@ -23,6 +23,8 @@ subcategory = 0
 title = FS4WC Biplane Wing Center(special aero)
 manufacturer = Bitesized Industries
 description = A center wing section from an old Biplane. Allows for easy mounting of a high wing span.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/FS_BiplaneWingMain.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneWingMain.cfg
@@ -19,6 +19,8 @@ TechRequired = start
 title = FS4WM Biplane Wing (special aero)
 manufacturer = Bitesized Industries
 description = The main wing section from an old Biplane, with a built in aileron. Provides only Yaw control unless re-configured.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/FS_BiplaneWingRound.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneWingRound.cfg
@@ -23,6 +23,8 @@ subcategory = 0
 title = FS4WR Bi-Plane Wing Round (special aero)
 manufacturer = Bitesized Industries
 description = A round wing section with a control surface from an old Biplane. Provide only Roll Control, unless re-configured.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/FS_BiplaneWingShort.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneWingShort.cfg
@@ -23,6 +23,8 @@ subcategory = 0
 title = FS4WS Biplane Wing Short (special aero)
 manufacturer = Bitesized Industries
 description = A half length wing from an old Biplane.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/FS_BiplaneWingTip.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneWingTip.cfg
@@ -25,6 +25,7 @@ manufacturer = Bitesized Industries
 description = A mostly cosmetic part. provides a tiny amount of lift. From an old Biplane.// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 bulkheadProfiles = srf
 
+// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 
 // --- node definitions ---

--- a/For release/Firespitter/Parts/FS_BiplaneWingTip.cfg
+++ b/For release/Firespitter/Parts/FS_BiplaneWingTip.cfg
@@ -23,6 +23,8 @@ subcategory = 0
 title = FS4WT Biplane Wing Tip (special aero)
 manufacturer = Bitesized Industries
 description = A mostly cosmetic part. provides a tiny amount of lift. From an old Biplane.// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+bulkheadProfiles = srf
+
 attachRules = 0,1,0,1,1
 
 // --- node definitions ---

--- a/For release/Firespitter/Parts/FS_OblongToRoundAdapter.cfg
+++ b/For release/Firespitter/Parts/FS_OblongToRoundAdapter.cfg
@@ -29,6 +29,7 @@ subcategory = 0
 title = FS1ORA Oblong to Round Adapter
 manufacturer = Bitesized Industries
 description = Easily mix and match regular round parts with oblong parts with this stylish adapter.
+bulkheadProfiles = oblong, size1
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,1,0

--- a/For release/Firespitter/Parts/FuelTank/FS_airTank/part.cfg
+++ b/For release/Firespitter/Parts/FuelTank/FS_airTank/part.cfg
@@ -19,6 +19,7 @@ subcategory = 0
 title = FS3AT Air Tank
 manufacturer = Bitesized Industries
 description = Top quality air from the top of Mount Nibrek, squeezed into a tank, for your aviation needs
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1

--- a/For release/Firespitter/Parts/FuelTank/FS_dropTank/part.cfg
+++ b/For release/Firespitter/Parts/FuelTank/FS_dropTank/part.cfg
@@ -20,6 +20,7 @@ subcategory = 0
 title = FS3FD Fuel Drop Tank
 manufacturer = Bitesized Industries
 description = Drop it like it's hot!
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,1

--- a/For release/Firespitter/Parts/FuelTank/FS_dropTankMount/part.cfg
+++ b/For release/Firespitter/Parts/FuelTank/FS_dropTankMount/part.cfg
@@ -20,6 +20,7 @@ subcategory = 0
 title = FS3FDM Drop Tank Mount
 manufacturer = Bitesized Industries
 description = Hold a drop tank. This part also separates from the craft.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,1

--- a/For release/Firespitter/Parts/FuelTank/FS_jerryCan/part.cfg
+++ b/For release/Firespitter/Parts/FuelTank/FS_jerryCan/part.cfg
@@ -27,6 +27,8 @@ subcategory = 0
 title = FS3J Jerry Can
 manufacturer = Bitesized Industries
 description = You don't want to run out of gas driving you rover do you?
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0
 

--- a/For release/Firespitter/Parts/FuelTank/FS_oxidizerTank/part.cfg
+++ b/For release/Firespitter/Parts/FuelTank/FS_oxidizerTank/part.cfg
@@ -19,6 +19,7 @@ subcategory = 0
 title = FS3OT Oxidizer Tank
 manufacturer = Bitesized Industries
 description = When you need just a little bit of Oxidizer, without all that nasty liquid fuel it usually comes bundled with, this is for you!
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1

--- a/For release/Firespitter/Parts/Fuselage/FS_bombBay/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_bombBay/part.cfg
@@ -25,6 +25,7 @@ subcategory = 0
 title = FS1BB Bomb Bay
 manufacturer = Bitesized Industries
 description = Load it up with supplies for hungry refugees, or keep the war industry rolling. Your choice. "Red flowers bursting down below us, those people didn't even know us" -Cake
+bulkheadProfiles = size2
 
 attachRules = 1,1,1,1,0
 

--- a/For release/Firespitter/Parts/Fuselage/FS_bombBay/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_bombBay/part.cfg
@@ -27,6 +27,7 @@ manufacturer = Bitesized Industries
 description = Load it up with supplies for hungry refugees, or keep the war industry rolling. Your choice. "Red flowers bursting down below us, those people didn't even know us" -Cake
 bulkheadProfiles = size2
 
+// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0
 
 mass = 1.2

--- a/For release/Firespitter/Parts/Fuselage/FS_bomberFuselage/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_bomberFuselage/part.cfg
@@ -21,6 +21,7 @@ subcategory = 0
 title = FS1BF Bomber Fuselage
 manufacturer = Bitesized Industries
 description = The middle section of the K-17 Flying House
+bulkheadProfiles = size2
 
 attachRules = 1,1,1,1,0
 

--- a/For release/Firespitter/Parts/Fuselage/FS_bomberFuselage/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_bomberFuselage/part.cfg
@@ -23,6 +23,7 @@ manufacturer = Bitesized Industries
 description = The middle section of the K-17 Flying House
 bulkheadProfiles = size2
 
+// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0
 
 mass = 1.2

--- a/For release/Firespitter/Parts/Fuselage/FS_bomberFuselageTail/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_bomberFuselageTail/part.cfg
@@ -21,6 +21,7 @@ subcategory = 0
 title = FS1BT Bomber Tail
 manufacturer = Bitesized Industries
 description = The tail section of the K-17 Flying House
+bulkheadProfiles = size2, size0
 
 attachRules = 1,1,1,1,0
 

--- a/For release/Firespitter/Parts/Fuselage/FS_bomberFuselageTail/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_bomberFuselageTail/part.cfg
@@ -23,6 +23,7 @@ manufacturer = Bitesized Industries
 description = The tail section of the K-17 Flying House
 bulkheadProfiles = size2, size0
 
+// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0
 
 mass = 0.9

--- a/For release/Firespitter/Parts/Fuselage/FS_crewFuselage/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_crewFuselage/part.cfg
@@ -32,6 +32,7 @@ subcategory = 0
 title = FS2CF Passenger Fuselage
 manufacturer = Bitesized Industries
 description = A fuselage section for helicopters or airplanes, carrying two passengers and a bit of fuel. If you're going to send it into space, please seal the doors with duct tape.
+bulkheadProfiles = size1
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Fuselage/FS_oblongFuselageHalf/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_oblongFuselageHalf/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS1OFH Oblong Structural Fuselage (Half Length)
 manufacturer = Bitesized Industries
 description = Sleek and possibly aerodynamic, a short fuselage for the slightly daring among you!
+bulkheadProfiles = oblong
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Fuselage/FS_oblongMultiTank/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_oblongMultiTank/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS1OMT Oblong Multi-tank
 manufacturer = Bitesized Industries
 description = Switch between many fuel tank options in a single part!
+bulkheadProfiles = oblong
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Fuselage/FS_oblongNose/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_oblongNose/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS1ON Oblong Nose
 manufacturer = Bitesized Industries
 description = A nose fit for a wild horse of some kind. Or its equivalent fighter plane.
+bulkheadProfiles = oblong
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Fuselage/FS_oblongNoseLong/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_oblongNoseLong/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS1ONL Oblong Long Nose
 manufacturer = Bitesized Industries
 description = A long rounded end piece for oblong fuselages
+bulkheadProfiles = oblong
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Fuselage/FS_oblongNoseRound/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_oblongNoseRound/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS1ONR Oblong Rounded Nose
 manufacturer = Bitesized Industries
 description = A rounded end piece for oblong fuselages
+bulkheadProfiles = oblong
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Fuselage/FS_oblongTail/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_oblongTail/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS1OT Oblong Tail
 manufacturer = Bitesized Industries
 description = Sleek and possibly aerodynamic, a fuselage for the daredevils among you!
+bulkheadProfiles = oblong
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Fuselage/FS_oblongToRoundAdapter/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_oblongToRoundAdapter/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS1ORA Oblong to Round Adapter
 manufacturer = Bitesized Industries
 description = Easily mix and match regular round parts with oblong parts with this stylish adapter.
+bulkheadProfiles = oblong, size1
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Fuselage/FS_oblongToSmallAdapter/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_oblongToSmallAdapter/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS1OSA Oblong to Small Adapter
 manufacturer = Bitesized Industries
 description = Easily mix and match regular round 0.625m parts and oblong parts with this stylish adapter.
+bulkheadProfiles = oblong, size0
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Fuselage/FS_tailBoom/part.cfg
+++ b/For release/Firespitter/Parts/Fuselage/FS_tailBoom/part.cfg
@@ -30,6 +30,7 @@ category = Structural
 title = FS2TB Tail Boom
 manufacturer = Bitesized Industries
 description = The thing that makes your tail rotor get some distance from the rest of your helicopter.
+bulkheadProfiles = oblong
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Structural/FS_engineMount/part.cfg
+++ b/For release/Firespitter/Parts/Structural/FS_engineMount/part.cfg
@@ -28,6 +28,7 @@ category = Aero
 title = FS1EM Wing Engine Mount
 manufacturer = Bitesized Industries
 description = The final resting place for your engines.
+bulkheadProfiles = srf, size1
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,1

--- a/For release/Firespitter/Parts/Structural/FS_floatEndNose/part.cfg
+++ b/For release/Firespitter/Parts/Structural/FS_floatEndNose/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS4SFN Seaplane Float (Nose)
 manufacturer = Bitesized Industries
 description = Why land on hilly, bumpy hard dirt when you can land on endless flat splashy splash?
+bulkheadProfiles = float1
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Structural/FS_floatEndTail/part.cfg
+++ b/For release/Firespitter/Parts/Structural/FS_floatEndTail/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS4SFT Seaplane Float (Tail)
 manufacturer = Bitesized Industries
 description = A float tail with a non lifting rudder. Only steers in water, and doesn't affect your lift readout in the hangar.
+bulkheadProfiles = float1
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Structural/FS_floatGearbay/part.cfg
+++ b/For release/Firespitter/Parts/Structural/FS_floatGearbay/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS4SFG Seaplane Float (Gear bay)
 manufacturer = Bitesized Industries
 description = Roll on lands, floats on the sea, soars through the air like a beagle.
+bulkheadProfiles = float1
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Structural/FS_floatStraight/part.cfg
+++ b/For release/Firespitter/Parts/Structural/FS_floatStraight/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS4SFS Seaplane Float (Straight)
 manufacturer = Bitesized Industries
 description = Why land on hilly, bumpy hard dirt when you can land on endless flat splashy splash?
+bulkheadProfiles = float1
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Structural/FS_floatStrut/part.cfg
+++ b/For release/Firespitter/Parts/Structural/FS_floatStrut/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS4SFST Seaplane Float (Strut)
 manufacturer = Bitesized Industries
 description = Why land on hilly, bumpy hard dirt when you can land on endless flat splashy splash?
+bulkheadProfiles = float1
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Structural/FS_landingPads/part.cfg
+++ b/For release/Firespitter/Parts/Structural/FS_landingPads/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS3LP Helicopter Landing Pads
 manufacturer = Bitesized Industries
 description = Featuring brand new Stay Put technology by Justin Kerbice, this landing system ensures you don't roll away.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Utility/FS_Gyroscope/part.cfg
+++ b/For release/Firespitter/Parts/Utility/FS_Gyroscope/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS2G ASAS Gyroscope
 manufacturer = Bitesized Industries
 description = Somehow this little thing will keep your aircraft level. It was found in the back of a novelty shop, so use at your own peril. Can be mounted on the sides of your craft.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,0

--- a/For release/Firespitter/Parts/Utility/FS_airBrake/part.cfg
+++ b/For release/Firespitter/Parts/Utility/FS_airBrake/part.cfg
@@ -21,6 +21,7 @@ subcategory = 0
 title = FS1AB Air Brake
 manufacturer = Bitesized Industries
 description = Whoa! Slow Down!
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,1

--- a/For release/Firespitter/Parts/Utility/FS_apacheNoseASAS/part.cfg
+++ b/For release/Firespitter/Parts/Utility/FS_apacheNoseASAS/part.cfg
@@ -28,6 +28,7 @@ subcategory = 0
 title = FS2NASAS Nose ASAS unit
 manufacturer = Bitesized Industries
 description = Steady your craft with this powerful nose mounted stability computing computer. Comes off a brand new Apache, only crashed once.
+bulkheadProfiles = size0
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0

--- a/For release/Firespitter/Parts/Utility/FS_battery/part.cfg
+++ b/For release/Firespitter/Parts/Utility/FS_battery/part.cfg
@@ -27,6 +27,8 @@ subcategory = 0
 title = FS3B Big Battery
 manufacturer = Bitesized Industries
 description = It's a damn big battery. Using the latest in LE-PT battery technology it will hold a charge for a long time.The LE-PT standard was developed with heavy funding from the Potato and Citrus Fruit Farmer Lobby.
+bulkheadProfiles = size1
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0
 

--- a/For release/Firespitter/Parts/Utility/FS_infoPopup/part.cfg
+++ b/For release/Firespitter/Parts/Utility/FS_infoPopup/part.cfg
@@ -28,6 +28,7 @@ subcategory = 0
 title = FS3I Info popup
 manufacturer = Bitesized Industries
 description = Displays editable info about the craft when you launch, or upon request. Press i to show the popup, or click on it in the actions editor.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,1

--- a/For release/Firespitter/Parts/Utility/FS_moveCraftGadget/part.cfg
+++ b/For release/Firespitter/Parts/Utility/FS_moveCraftGadget/part.cfg
@@ -27,6 +27,7 @@ subcategory = 0
 title = FS3WL Water Launch System
 manufacturer = Bitesized Industries
 description = Autmatically places your craft in the water near KSC at launch. Quicksave and Quickload the game after launch if wings or other parts lock up. (Hold F5 and F9)
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,1

--- a/For release/Firespitter/Parts/Utility/FS_trimGadget/part.cfg
+++ b/For release/Firespitter/Parts/Utility/FS_trimGadget/part.cfg
@@ -28,6 +28,7 @@ subcategory = 0
 title = FS3TA Trim Adjustment Gadget
 manufacturer = Bitesized Industries
 description = Control trim with presets, in fligth, or set them up in the hangar action editor popup.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,1

--- a/For release/Firespitter/Parts/Wheel/FS_BiplaneGear/part.cfg
+++ b/For release/Firespitter/Parts/Wheel/FS_BiplaneGear/part.cfg
@@ -84,6 +84,7 @@ subcategory = 0
 title = FS4LGS Biplane Single Landing Gear
 manufacturer = Bitesized Industries
 description = An single landing gear from a biplane
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,1

--- a/For release/Firespitter/Parts/Wheel/FS_apacheLandingGear/part.cfg
+++ b/For release/Firespitter/Parts/Wheel/FS_apacheLandingGear/part.cfg
@@ -97,6 +97,7 @@ subcategory = 0
 title = FS2LGA Helicopter Landing Gear
 manufacturer = Bitesized Industries
 description = A landing gear from an attack helicopter.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,1

--- a/For release/Firespitter/Parts/Wheel/FS_apacheLandingGearFlip/part.cfg
+++ b/For release/Firespitter/Parts/Wheel/FS_apacheLandingGearFlip/part.cfg
@@ -102,6 +102,7 @@ subcategory = 0
 title = FS2LGAS Swivelling Helicopter Landing Gear
 manufacturer = Bitesized Industries
 description = First: These will look dumb in the SPH/VAB, but they will look right when you launch! A landing gear from an attack helicopter. Swivels out depending on which side of the crat it is on for more stable landings.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,1

--- a/For release/Firespitter/Parts/Wheel/FS_bomberLandingGear/part.cfg
+++ b/For release/Firespitter/Parts/Wheel/FS_bomberLandingGear/part.cfg
@@ -97,6 +97,7 @@ subcategory = 0
 title = FS1LGB Bomber Landing Gear
 manufacturer = Bitesized Industries
 description = An old landing gear from a large bomber.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,1

--- a/For release/Firespitter/Parts/Wheel/FS_fighterLandingGear/part.cfg
+++ b/For release/Firespitter/Parts/Wheel/FS_fighterLandingGear/part.cfg
@@ -97,6 +97,7 @@ subcategory = 0
 title = FS1LG2 Fighter Landing Gear
 manufacturer = Bitesized Industries
 description = An old landing gear from a decommisioned fighter plane.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,1

--- a/For release/Firespitter/Parts/Wheel/FS_fighterTailGear/part.cfg
+++ b/For release/Firespitter/Parts/Wheel/FS_fighterTailGear/part.cfg
@@ -32,6 +32,7 @@ subcategory = 0
 title = FS1TG Fighter Tail Gear
 manufacturer = Bitesized Industries
 description = An old tail gear from a decommisioned fighter plane.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,0

--- a/For release/Firespitter/Parts/biPlane/FS_biPlaneElevator/part.cfg
+++ b/For release/Firespitter/Parts/biPlane/FS_biPlaneElevator/part.cfg
@@ -30,6 +30,8 @@ subcategory = 0
 title = *LEGACY* FS4E Biplane Elevator (special aero)
 manufacturer = Bitesized Industries
 description = A tail elevator from an old Biplane. Provides only Pitch control unless re-configured.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/biPlane/FS_biPlaneRudder/part.cfg
+++ b/For release/Firespitter/Parts/biPlane/FS_biPlaneRudder/part.cfg
@@ -30,6 +30,8 @@ subcategory = 0
 title = *LEGACY* FS4R Biplane Rudder (special aero)
 manufacturer = Bitesized Industries
 description = A rudder from an old Biplane. Provides only Yaw control unless re-configured.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/biPlane/FS_biPlaneSkid/part.cfg
+++ b/For release/Firespitter/Parts/biPlane/FS_biPlaneSkid/part.cfg
@@ -58,6 +58,7 @@ subcategory = 0
 title = *LEGACY* FS4SKD Biplane Tail Skid
 manufacturer = Bitesized Industries
 description = When wheels are just too high tech! You can actually steer with this thing on the tail of your plane. It will also help slow you down after a landing (without keeping you from taking off from a stand still). For extra protection, use some of these in a non steering setup on your wing tips for added impact protection, just like on the historic Fokker DR1.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,1

--- a/For release/Firespitter/Parts/biPlane/FS_biPlaneTailFuselage/part.cfg
+++ b/For release/Firespitter/Parts/biPlane/FS_biPlaneTailFuselage/part.cfg
@@ -21,6 +21,8 @@ subcategory = 0
 title = *LEGACY* FS4FT Biplane Tail Fuselage
 manufacturer = Bitesized Industries
 description = A tail section from an old bi-plane
+bulkheadProfiles = oblong
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,1
 

--- a/For release/Firespitter/Parts/biPlane/FS_biPlaneWingCenter/part.cfg
+++ b/For release/Firespitter/Parts/biPlane/FS_biPlaneWingCenter/part.cfg
@@ -30,6 +30,8 @@ subcategory = 0
 title = *LEGACY* FS4WC Biplane Wing Center(special aero)
 manufacturer = Bitesized Industries
 description = A center wing section from an old Biplane. Allows for easy mounting of a high wing span.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/biPlane/FS_biPlaneWingMain/part.cfg
+++ b/For release/Firespitter/Parts/biPlane/FS_biPlaneWingMain/part.cfg
@@ -30,6 +30,8 @@ subcategory = 0
 title = *LEGACY* FS4WM Biplane Wing (special aero)
 manufacturer = Bitesized Industries
 description = The main wing section from an old Biplane, with a built in aileron. Provides only Yaw control unless re-configured.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/biPlane/FS_biPlaneWingRound/part.cfg
+++ b/For release/Firespitter/Parts/biPlane/FS_biPlaneWingRound/part.cfg
@@ -30,6 +30,8 @@ subcategory = 0
 title = *LEGACY* FS4WR Bi-Plane Wing Round (special aero)
 manufacturer = Bitesized Industries
 description = A round wing section with a control surface from an old Biplane. Provide only Roll Control, unless re-configured.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/biPlane/FS_biPlaneWingShort/part.cfg
+++ b/For release/Firespitter/Parts/biPlane/FS_biPlaneWingShort/part.cfg
@@ -30,6 +30,8 @@ subcategory = 0
 title = *LEGACY* FS4WS Biplane Wing Short (special aero)
 manufacturer = Bitesized Industries
 description = A half length wing from an old Biplane.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/biPlane/FS_biPlaneWingTip/part.cfg
+++ b/For release/Firespitter/Parts/biPlane/FS_biPlaneWingTip/part.cfg
@@ -30,6 +30,8 @@ subcategory = 0
 title = *LEGACY* FS4WT Biplane Wing Tip (special aero)
 manufacturer = Bitesized Industries
 description = A mostly cosmetic part. provides a tiny amount of lift. From an old Biplane.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/biPlane/FS_biplaneAileron/part.cfg
+++ b/For release/Firespitter/Parts/biPlane/FS_biplaneAileron/part.cfg
@@ -30,6 +30,8 @@ subcategory = 0
 title = *LEGACY* FS4A Biplane Aileron (special aero)
 manufacturer = Bitesized Industries
 description = An aileron from an old Bi-Plane. Provides only Roll control unless re-configured.
+bulkheadProfiles = srf
+
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,1,1
 

--- a/For release/Firespitter/Parts/biPlane/FS_biplaneCockpit/part.cfg
+++ b/For release/Firespitter/Parts/biPlane/FS_biplaneCockpit/part.cfg
@@ -36,6 +36,7 @@ subcategory = 0
 title = *LEGACY* FS4BC Biplane Cockpit
 manufacturer = Bitesized Industries
 description = From a time when Men were Men, and Kerbals were Kerbals. Dress code is strictly enforced.
+bulkheadProfiles = oblong
 
 //attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,0,1,1,0

--- a/For release/Firespitter/Parts/biPlane/FS_strutConnectorWire/part.cfg
+++ b/For release/Firespitter/Parts/biPlane/FS_strutConnectorWire/part.cfg
@@ -20,6 +20,7 @@ subcategory = 0
 title = *LEGACY* FS4SW Biplane wire strut connector
 manufacturer = Bitesized Industries
 description = Hold things together in a stylish fashion, while also saying you're not afraid of open flame or wire cutters.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,1

--- a/For release/Firespitter/Parts/biPlane/FS_strutConnectorWood/part.cfg
+++ b/For release/Firespitter/Parts/biPlane/FS_strutConnectorWood/part.cfg
@@ -20,6 +20,7 @@ subcategory = 0
 title = *LEGACY* FS4SD Biplane wooden beam connector
 manufacturer = Bitesized Industries
 description = Keeps your top wing from flapping into you bottom wing.
+bulkheadProfiles = srf
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 0,1,0,0,1


### PR DESCRIPTION
This Pull Request adds (proper) missing bulkheadProfiles to Firespitter parts, allowing them to be correctly used on KSP >= 1.6 without workarounds