### PR TITLE
Update .version file for KSP 1.12.x compat

### DIFF
--- a/For release/Firespitter/Firespitter.version
+++ b/For release/Firespitter/Firespitter.version
@@ -18,7 +18,7 @@
      },
      "KSP_VERSION_MAX":{
          "MAJOR":1,
-         "MINOR":11,
+         "MINOR":12,
          "PATCH":99
      }
 }

--- a/For release/Firespitter/Firespitter.version
+++ b/For release/Firespitter/Firespitter.version
@@ -8,8 +8,8 @@
   },
      "KSP_VERSION":{
          "MAJOR":1,
-         "MINOR":11,
-         "PATCH":0
+         "MINOR":12,
+         "PATCH":3
      },
      "KSP_VERSION_MIN":{
          "MAJOR":1,


### PR DESCRIPTION
@BobPalmer Over the past year or so Firespitter has looked pretty solid on KSP 1.12, so it'd be awesome if the .version file allowed it to be installed by CKAN rather than requiring either (a) a manual install or (b) setting a compat flag in the CKAN client (which can do other weird things if other mods' versioning is weird).

Cheers!