### PR TITLE
Remove active vessel restriction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,5 @@ pip-log.txt
 #Mr Developer
 .mr.developer.cfg
 *.zip
+/.vs/slnx.sqlite
+/.vs/VSWorkspaceState.json

--- a/Firespitter/aero/FSairBrake.cs
+++ b/Firespitter/aero/FSairBrake.cs
@@ -86,7 +86,7 @@ public class FSairBrake : PartModule // Inspired by Vlad Just Vlad's airbrake pl
 
     public void FixedUpdate()
     {        
-        if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel) return;
+        if (!HighLogic.LoadedSceneIsFlight) return;
 
 
         float angleChange = targetAngle - currentAngle;

--- a/Firespitter/animation/FSanimatedAirIntake.cs
+++ b/Firespitter/animation/FSanimatedAirIntake.cs
@@ -29,7 +29,7 @@ public class FSanimatedAirIntake : PartModule
     public override void OnFixedUpdate()
     {
         base.OnFixedUpdate();
-        if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel) return;
+        if (!HighLogic.LoadedSceneIsFlight) return;
         if (intakeMeshTransform != null && intakeModule != null)
         {
             float modifiedFlow = intakeModule.airFlow - flowAtAnimateStart;

--- a/Firespitter/cockpit/FSActionGroupSwitch.cs
+++ b/Firespitter/cockpit/FSActionGroupSwitch.cs
@@ -237,7 +237,7 @@ namespace Firespitter.cockpit
             if (CameraManager.Instance.currentCameraMode == CameraManager.CameraMode.IVA
                 || CameraManager.Instance.currentCameraMode == CameraManager.CameraMode.Internal)
             {
-                bool groupState = FlightGlobals.ActiveVessel.ActionGroups.groups[actionGroupNumber];
+                bool groupState = vessel.ActionGroups.groups[actionGroupNumber];
 
                 if (switchTypeEnum == SwitchType.flipSwitch)
                 {

--- a/Firespitter/cockpit/FSinternalPropRotator.cs
+++ b/Firespitter/cockpit/FSinternalPropRotator.cs
@@ -82,9 +82,9 @@ public class FSinternalPropRotator : InternalModule
     {
         base.OnUpdate();
 
-        if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel) return;
+        if (!HighLogic.LoadedSceneIsFlight) return;
 
-        smoothBrake = Mathf.Lerp(smoothBrake, (FlightGlobals.ActiveVessel.ActionGroups.groups[brakeActionInt] ? 1 : 0), 0.1f);
+        smoothBrake = Mathf.Lerp(smoothBrake, (vessel.ActionGroups.groups[brakeActionInt] ? 1 : 0), 0.1f);
 
         if (CameraManager.Instance.currentCameraMode == CameraManager.CameraMode.IVA
             || CameraManager.Instance.currentCameraMode == CameraManager.CameraMode.Internal)

--- a/Firespitter/cockpit/FSmonitorScript.cs
+++ b/Firespitter/cockpit/FSmonitorScript.cs
@@ -138,7 +138,7 @@ namespace Firespitter.cockpit
         public override void OnUpdate()
         {
             base.OnUpdate();
-            if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel) return;
+            if (!HighLogic.LoadedSceneIsFlight) return;
 
             // Run once. (Must be run after all parts have been created, so it can't be in the OnAwake)
             if (!monitorDefaultStateSet)

--- a/Firespitter/control/FSmoveCraftAtLaunch.cs
+++ b/Firespitter/control/FSmoveCraftAtLaunch.cs
@@ -210,7 +210,7 @@ public class FSmoveCraftAtLaunch : PartModule
     {
 		if (this.hasLaunched) return;
 		if (this.isDefaultPosition) return;
-        if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel) return;
+        if (!HighLogic.LoadedSceneIsFlight) return;
         
         {
             //Debug.Log("FSmoveCraftAtLaunch: Launching vessel at " + positionDisplayName + ", lat " + latitude + ", long " + longitude + ", alt " + altitude);

--- a/Firespitter/engine/FS engine modules/FSengineBladed.cs
+++ b/Firespitter/engine/FS engine modules/FSengineBladed.cs
@@ -221,7 +221,7 @@ namespace Firespitter.engine
 
         public override void FixedUpdate()
         {
-            if (!HighLogic.LoadedSceneIsFlight || !flightStarted || vessel != FlightGlobals.ActiveVessel) return;
+            if (!HighLogic.LoadedSceneIsFlight || !flightStarted) return;
 
             float airDirection = getAirSpeed();
 

--- a/Firespitter/engine/FS engine modules/FSengineBladed.cs
+++ b/Firespitter/engine/FS engine modules/FSengineBladed.cs
@@ -314,7 +314,7 @@ namespace Firespitter.engine
         {
             base.OnUpdate();
 
-            if (!HighLogic.LoadedSceneIsFlight || !flightStarted || vessel != FlightGlobals.ActiveVessel) return;
+            if (!HighLogic.LoadedSceneIsFlight || !flightStarted) return;
 
             getCollectiveInput();
 

--- a/Firespitter/engine/FSrotorTrim.cs
+++ b/Firespitter/engine/FSrotorTrim.cs
@@ -144,7 +144,7 @@ namespace Firespitter.engine
         {
             if (initialized)
             {
-                if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel) return;
+                if (!HighLogic.LoadedSceneIsFlight) return;
 
                 FlightCtrlState ctrl = vessel.ctrlState;
 

--- a/Firespitter/engine/Stock based modules/FSVTOLrotator.cs
+++ b/Firespitter/engine/Stock based modules/FSVTOLrotator.cs
@@ -537,7 +537,7 @@ namespace Firespitter.engine
 
         public void FixedUpdate() // moved angle update to fixed update to make rotation speed indpendent of framerate
         {
-            if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel) return;
+            if (!HighLogic.LoadedSceneIsFlight) return;
 
             float angleChange = targetAngle - currentAngle;
 

--- a/Firespitter/engine/Stock based modules/FSengineHover.cs
+++ b/Firespitter/engine/Stock based modules/FSengineHover.cs
@@ -98,7 +98,7 @@ namespace Firespitter.engine
         public override void OnFixedUpdate()
         {
             base.OnFixedUpdate();
-            if (HighLogic.LoadedSceneIsFlight && vessel == FlightGlobals.ActiveVessel)
+            if (HighLogic.LoadedSceneIsFlight)
             {
                 if (hoverActive)
                 {

--- a/Firespitter/engine/Stock based modules/FShoverThrottle.cs
+++ b/Firespitter/engine/Stock based modules/FShoverThrottle.cs
@@ -156,7 +156,7 @@ namespace Firespitter.engine
         public override void OnUpdate()
         {
             base.OnUpdate();
-            if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel || !engine.EngineIgnited) return;
+            if (!HighLogic.LoadedSceneIsFlight || !engine.EngineIgnited) return;
 
             double pqsAltitude = vessel.pqsAltitude;
             if (pqsAltitude < 0) pqsAltitude = 0;

--- a/Firespitter/engine/Stock based modules/FSmultiAxisEngine.cs
+++ b/Firespitter/engine/Stock based modules/FSmultiAxisEngine.cs
@@ -238,7 +238,7 @@ namespace Firespitter.engine
         public override void OnFixedUpdate()
         {
             base.OnFixedUpdate();
-            if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel) return;
+            if (!HighLogic.LoadedSceneIsFlight) return;
             FlightCtrlState ctrl = vessel.ctrlState;
             Vector3 steeringInput = new Vector3(0, 0, 0);
 

--- a/Firespitter/engine/Stock based modules/FSpropellerAtmosphericNerf.cs
+++ b/Firespitter/engine/Stock based modules/FSpropellerAtmosphericNerf.cs
@@ -49,7 +49,7 @@ namespace Firespitter.engine
 
         public override void OnUpdate()
         {
-            if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel) return;
+            if (!HighLogic.LoadedSceneIsFlight) return;
             float atmosphericModifier = ((float)part.staticPressureAtm * thrustModifier);
             if ((atmosphericModifier > 1f && thrustModifier > 1f) || disableAtmosphericNerf) atmosphericModifier = 1f; // not setting modifier to 1 at thrustModifier 1 or lower allows for engine that are better than normal in atmospeheres above 1
             float newThrust = fullThrottle * atmosphericModifier * engineModeModifier * steeringModifier;

--- a/Firespitter/engine/Stock based modules/FStailRotorThrust.cs
+++ b/Firespitter/engine/Stock based modules/FStailRotorThrust.cs
@@ -131,7 +131,7 @@ namespace Firespitter.engine
         {
             if (initialized)
             {
-                if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel) return;
+                if (!HighLogic.LoadedSceneIsFlight) return;
                 FlightCtrlState ctrl = vessel.ctrlState;
                 Vector3 steeringInput = new Vector3(0, 0, 0);
 

--- a/Firespitter/engine/Stock based modules/FSthrottlePropSpinner.cs
+++ b/Firespitter/engine/Stock based modules/FSthrottlePropSpinner.cs
@@ -15,7 +15,7 @@ public class FSthrottlePropSpinner : PartModule
 
     public override void OnUpdate()
     {
-        if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel) return; 
+        if (!HighLogic.LoadedSceneIsFlight) return; 
 
         var engine = part.Modules.OfType<ModuleEngines>().FirstOrDefault();
 

--- a/Firespitter/water/FSrudder.cs
+++ b/Firespitter/water/FSrudder.cs
@@ -138,7 +138,7 @@ public class FSrudder : PartModule
     public void FixedUpdate()
     {
         //base.OnFixedUpdate();
-        if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel) return;
+        if (!HighLogic.LoadedSceneIsFlight) return;
 
         if (firstRun)
         {

--- a/Firespitter/wheel/FSpartTurner.cs
+++ b/Firespitter/wheel/FSpartTurner.cs
@@ -296,7 +296,7 @@ using UnityEngine;
 
         public override void OnUpdate()
         {
-            if (!HighLogic.LoadedSceneIsFlight || !vessel.isActiveVessel) return;
+            if (!HighLogic.LoadedSceneIsFlight) return;
             FlightCtrlState ctrl = vessel.ctrlState;
 
             int reverseModifier = 1;

--- a/Firespitter/wheel/FSwheel.cs
+++ b/Firespitter/wheel/FSwheel.cs
@@ -805,7 +805,7 @@ class FSwheel : PartModule
 
         #region Active vessel code        
 
-        if (vessel.isActiveVessel && base.vessel.IsControllable)
+        if (base.vessel.IsControllable)
         {
             disableColliders();
 


### PR DESCRIPTION
Remove condition that vessel be the active vessel from various code sections where user keyboard input is not required, this fixes these engines not working when the vessel is not the active vessel (most noticeable during BDA dogfights where active vessel is switching between different craft in the dogfight).